### PR TITLE
Add a custom recipe to do argsort for easier chart generation

### DIFF
--- a/custom-recipes/argsort/recipe.json
+++ b/custom-recipes/argsort/recipe.json
@@ -1,0 +1,46 @@
+{
+    // Meta data for display purposes
+    "meta" : {
+        "label" : "Argsort",
+        "description" : "Add a column indicating the index necessary to sort another one",
+        "icon" : "icon-sort-by-attributes"
+    },
+
+    "kind" : "PYTHON",
+    
+    "inputRoles" : [
+         {
+            "name": "input_dataset",
+            "label": "Input dataset",
+            "description": "",
+            "arity": "UNARY",
+            "required": true,
+            "acceptsDataset": true
+        }
+    ],
+
+    "outputRoles" : [
+        {
+            "name": "output_dataset",
+            "label": "Output dataset",
+            "description": "",
+            "arity": "UNARY",
+            "required": true,
+            "acceptsDataset": true
+        }
+    ],
+    
+    params = [
+        {
+            "name": "argsort_column",
+            "type": "COLUMN",
+            "columnRole": "input_dataset",
+            "label": "Column",
+            "description": "",
+            "mandatory": true
+        }
+    ],
+
+    "resourceKeys" : []
+
+}

--- a/custom-recipes/argsort/recipe.py
+++ b/custom-recipes/argsort/recipe.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+import os
+
+import pandas as pd, numpy as np
+import keras
+
+import dataiku
+from dataiku.customrecipe import *
+from dataiku import pandasutils as pdu
+
+
+config = get_recipe_config()
+input_df = dataiku.Dataset(get_input_names_for_role('input_dataset')[0]).get_dataframe()
+argsort_column = config['argsort_column']
+
+input_df[argsort_column + '_argsort'] = input_df[argsort_column].rank(method='max')
+
+output_dataset = dataiku.Dataset(get_output_names_for_role('output_dataset')[0])
+output_dataset.write_with_schema(input_df)


### PR DESCRIPTION
Adds an argsort recipe. The rationale is that evaluations generated by the iterations are indexed by timestamps and are not easy to plot. This recipe adds a column with the index of the timestamps.