### PR TITLE
Move random query sampling to the classic recipe

### DIFF
--- a/custom-recipes/naive_sampler/recipe.json
+++ b/custom-recipes/naive_sampler/recipe.json
@@ -61,7 +61,6 @@
             "label" : "Query strategy",
             "type" : "SELECT",
             "selectChoices" : [
-                { "value" : "random", "label" : "Random sampling"},
                 { "value" : "density", "label" : "Density-based sampling"}
             ]
         }

--- a/custom-recipes/naive_sampler/recipe.py
+++ b/custom-recipes/naive_sampler/recipe.py
@@ -30,7 +30,6 @@ else:
 X = model.get_predictor().get_preprocessing().preprocess(unlabeled_df)[0]
 
 strategy_mapper = {
-    'random': random.random_sampling,
     'density': density.density_sampling
 }
 

--- a/custom-recipes/query_sampler/recipe.json
+++ b/custom-recipes/query_sampler/recipe.json
@@ -77,6 +77,7 @@
             "label" : "Query strategy",
             "type" : "SELECT",
             "selectChoices" : [
+                { "value" : "random", "label" : "Random sampling"},
                 { "value" : "uncertainty", "label" : "Uncertainty sampling"},
                 { "value" : "margin", "label" : "Margin sampling"},
                 { "value" : "entropy", "label" : "Entropy based sampling"}


### PR DESCRIPTION
If we consider that allowing several annotations is up to the webapp, we do not need the annotations in the random recipe. It can go in the query sampling recipe.