### PR TITLE
Lock sample batch by user for a period of time

### DIFF
--- a/python-lib/lal/handlers/lal_handler.py
+++ b/python-lib/lal/handlers/lal_handler.py
@@ -72,9 +72,9 @@ class LALHandler(object):
                     reserved_sample = self.sample_by_user_reservation.get(i)
                     if reserved_sample.reserved_until <= datetime.now():
                         del self.sample_by_user_reservation[i]
-                    else:
-                        if reserved_sample.username == self.current_user:
-                            result.append(i)
+                        result.append(i)
+                    elif reserved_sample.username == self.current_user:
+                        result.append(i)
                 else:
                     result.append(i)
         return result
@@ -143,8 +143,7 @@ class LALHandler(object):
         with LALHandler.lock:
             reserved_until = datetime.now() + timedelta(minutes=int(BATCH_SIZE * BLOCK_SAMPLE_BY_USER_FOR_MINUTES))
             for i in ids_batch:
-                if i not in self.sample_by_user_reservation:
-                    self.sample_by_user_reservation[i] = ReservedSample(self.current_user, reserved_until)
+                self.sample_by_user_reservation[i] = ReservedSample(self.current_user, reserved_until)
         ids_batch.reverse()
         return {
             "type": self.classifier.type,

--- a/python-lib/lal/handlers/lal_handler.py
+++ b/python-lib/lal/handlers/lal_handler.py
@@ -2,23 +2,40 @@ import hashlib
 import json
 import logging
 from abc import abstractmethod
-from datetime import datetime
-from typing import TypeVar
+from asyncio import Lock
+from datetime import datetime, timedelta
+from typing import TypeVar, Dict
 
 import pandas as pd
 
 from lal.classifiers.base_classifier import BaseClassifier
 
-META_STATUS_LABELED = 'LABELED'
+logging.basicConfig(level=logging.INFO, format='%(name)s %(levelname)s - %(message)s')
 
+META_STATUS_LABELED = 'LABELED'
 META_STATUS_SKIPPED = 'SKIPPED'
 
+BLOCK_SAMPLE_BY_USER_FOR_MINUTES = 0.5
 BATCH_SIZE = 20
 
 C = TypeVar('C', bound=BaseClassifier)
 
 
+class ReservedSample:
+    username: str
+    reserved_until: datetime
+
+    def __init__(self, username: str, reserved_until: datetime) -> None:
+        self.username = username
+        self.reserved_until = reserved_until
+
+    def __repr__(self) -> str:
+        return f"User: {self.username}; Reserved until: {self.reserved_until}"
+
+
 class LALHandler(object):
+    lock = Lock()
+    sample_by_user_reservation: Dict[str, ReservedSample] = dict()
     logger = logging.getLogger(__name__)
 
     def __init__(self, classifier, label_col_name, meta_df, labels_df, user, do_users_share_labels=True):
@@ -44,9 +61,22 @@ class LALHandler(object):
                 (self.meta_df.status == status) & (self.meta_df.annotator == self.current_user)]
 
     def get_remaining(self):
-        seen_ids = set(self.get_meta_by_status().data_id.values)
-        logging.info("get_remaining: Seen ids: {0}".format(seen_ids))
-        return [i for i in self.classifier.get_all_item_ids_list() if i not in seen_ids]
+        labeled_ids = set(self.get_meta_by_status().data_id.values)
+        logging.info("get_remaining: Seen ids: {0}".format(labeled_ids))
+        unlabeled_ids = [i for i in self.classifier.get_all_item_ids_list() if i not in labeled_ids]
+        result = []
+        with self.lock:
+            for i in unlabeled_ids:
+                if i in self.sample_by_user_reservation:
+                    reserved_sample = self.sample_by_user_reservation.get(i)
+                    if reserved_sample.reserved_until <= datetime.now():
+                        del self.sample_by_user_reservation[i]
+                    else:
+                        if reserved_sample.username == self.current_user:
+                            result.append(i)
+                else:
+                    result.append(i)
+        return result
 
     def calculate_stats(self):
         total_count = len(self.classifier.get_all_item_ids_list())
@@ -109,6 +139,11 @@ class LALHandler(object):
 
         remaining = self.get_remaining()
         ids_batch = remaining[-BATCH_SIZE:]
+        with self.lock:
+            for i in ids_batch:
+                if i not in self.sample_by_user_reservation:
+                    reserved_until = datetime.now() + timedelta(minutes=int(BATCH_SIZE * BLOCK_SAMPLE_BY_USER_FOR_MINUTES))
+                    self.sample_by_user_reservation[i] = ReservedSample(self.current_user, reserved_until)
         ids_batch.reverse()
         return {
             "type": self.classifier.type,

--- a/python-lib/lal/handlers/lal_handler.py
+++ b/python-lib/lal/handlers/lal_handler.py
@@ -63,7 +63,8 @@ class LALHandler(object):
     def get_remaining(self):
         labeled_ids = set(self.get_meta_by_status().data_id.values)
         logging.info("get_remaining: Seen ids: {0}".format(labeled_ids))
-        unlabeled_ids = [i for i in self.classifier.get_all_item_ids_list() if i not in labeled_ids]
+        unlabeled_ids = [item_id for item_id in self.classifier.get_all_item_ids_list() if item_id not in labeled_ids]
+        unlabeled_ids = [item_id for item_id in self.classifier.get_all_item_ids_list() if item_id not in labeled_ids]
         result = []
         with LALHandler.lock:
             for i in unlabeled_ids:
@@ -140,9 +141,9 @@ class LALHandler(object):
         remaining = self.get_remaining()
         ids_batch = remaining[-BATCH_SIZE:]
         with LALHandler.lock:
+            reserved_until = datetime.now() + timedelta(minutes=int(BATCH_SIZE * BLOCK_SAMPLE_BY_USER_FOR_MINUTES))
             for i in ids_batch:
                 if i not in self.sample_by_user_reservation:
-                    reserved_until = datetime.now() + timedelta(minutes=int(BATCH_SIZE * BLOCK_SAMPLE_BY_USER_FOR_MINUTES))
                     self.sample_by_user_reservation[i] = ReservedSample(self.current_user, reserved_until)
         ids_batch.reverse()
         return {

--- a/python-lib/lal/handlers/lal_handler.py
+++ b/python-lib/lal/handlers/lal_handler.py
@@ -64,7 +64,6 @@ class LALHandler(object):
         labeled_ids = set(self.get_meta_by_status().data_id.values)
         logging.info("get_remaining: Seen ids: {0}".format(labeled_ids))
         unlabeled_ids = [item_id for item_id in self.classifier.get_all_item_ids_list() if item_id not in labeled_ids]
-        unlabeled_ids = [item_id for item_id in self.classifier.get_all_item_ids_list() if item_id not in labeled_ids]
         result = []
         with LALHandler.lock:
             for i in unlabeled_ids:


### PR DESCRIPTION
Once a user start to label we send him a batch of samples. In order not to label the same data twice we need to lock this batch from being taken again by other users. 
Current implementation locks a batch for 30 seconds * batch size.

[Clubhouse card](https://app.clubhouse.io/dataiku/story/44044/lock-a-batch-of-sample-per-user-for-a-period-of-time)