### PR TITLE
Bugfix/fixes for prelabeling

### DIFF
--- a/python-lib/lal/classifiers/ner/text_classifier.py
+++ b/python-lib/lal/classifiers/ner/text_classifier.py
@@ -26,7 +26,7 @@ class TextClassifier(TableBasedDataClassifier):
         self.use_tokenization = True
         self.tokenizer = self.use_tokenization and MultilingualTokenizer()
         self.text_column = config.get("text_column")
-        self.label_column = config.get('label_col_name')
+        self.label_column_name = config.get('label_col_name')
         self.language = config.get("language")
         self.language_column = config.get("language_column")
         self.token_engine = config.get("tokenization_engine")
@@ -62,7 +62,7 @@ class TextClassifier(TableBasedDataClassifier):
     def build_history_from_meta(self, user_meta):
         history = {}
         for meta in user_meta:
-            for lab in self.deserialize_label(meta[self.label_column]):
+            for lab in self.deserialize_label(meta[self.label_column_name]):
                 txt = lab["text"].lower()
                 if txt in history and lab["label"] == history[txt]["label"]:
                     history[txt]["cpt"] += 1

--- a/python-lib/lal/classifiers/ner/text_classifier.py
+++ b/python-lib/lal/classifiers/ner/text_classifier.py
@@ -26,6 +26,7 @@ class TextClassifier(TableBasedDataClassifier):
         self.use_tokenization = True
         self.tokenizer = self.use_tokenization and MultilingualTokenizer()
         self.text_column = config.get("text_column")
+        self.label_column = config.get('label_col_name')
         self.language = config.get("language")
         self.language_column = config.get("language_column")
         self.token_engine = config.get("tokenization_engine")
@@ -61,7 +62,7 @@ class TextClassifier(TableBasedDataClassifier):
     def build_history_from_meta(self, user_meta):
         history = {}
         for meta in user_meta:
-            for lab in self.deserialize_label(meta["label"]):
+            for lab in self.deserialize_label(meta[self.label_column]):
                 txt = lab["text"].lower()
                 if txt in history and lab["label"] == history[txt]["label"]:
                     history[txt]["cpt"] += 1

--- a/python-lib/lal/classifiers/ner/text_classifier.py
+++ b/python-lib/lal/classifiers/ner/text_classifier.py
@@ -78,7 +78,8 @@ class TextClassifier(TableBasedDataClassifier):
         prelabels = []
         if not history:
             return prelabels
-        regexp = '({})'.format('|'.join(list(history.keys())))
+        history_keys = [re.escape(hk) for hk in list(history.keys())]
+        regexp = '({})'.format('|'.join(history_keys))
         regexp = ('\\b{}\\b' if self.token_engine == self.WHITESPACE_TOKEN_ENGINE else '{}').format(regexp)
         emojis = list(re.finditer(emoji.get_emoji_regexp(), text))
         for match in re.finditer(regexp, text, re.IGNORECASE):

--- a/resource/labeling-app/components/text-sample/TextArea.js
+++ b/resource/labeling-app/components/text-sample/TextArea.js
@@ -130,6 +130,7 @@ const TextArea = {
             tokenDOM.id = this.getTokenId(index);
             tokenDOM.setAttribute('data-start', token.start);
             tokenDOM.setAttribute('data-end', token.end);
+            tokenDOM.setAttribute('data-is-selectable', token.text.trim().length > 0);
             return tokenDOM
         },
         resetSelection() {
@@ -147,6 +148,9 @@ const TextArea = {
             let [startNode, endNode] = this.sanitizeBoundaryNodes(selection);
             if (!startNode || !endNode) return;
 
+            const nodesComparison = startNode.compareDocumentPosition(endNode);
+            if (![0, 4].includes(nodesComparison)) return;
+
             const [startToken, endToken] = [this.getTokenFromNode(startNode), this.getTokenFromNode(endNode)];
             if (!startToken || !endToken) return;
 
@@ -160,6 +164,14 @@ const TextArea = {
 
             startNode = startNode.nodeType === Node.TEXT_NODE ? startNode.parentElement : startNode;
             endNode = endNode.nodeType === Node.TEXT_NODE ? endNode.parentElement : endNode;
+
+            while(startNode.getAttribute('data-is-selectable') === 'false') {
+                startNode = startNode.nextElementSibling;
+            }
+
+            while (endNode.getAttribute('data-is-selectable') === 'false') {
+                endNode = endNode.previousElementSibling;
+            }
 
             const startToken = this.getTokenFromNode(startNode);
             if (!startToken || range.toString() === startToken.whitespace) {


### PR DESCRIPTION
# Introduction
A user has reported some problems when using the plugin (https://support.dataiku.com/a/tickets/30573). This PR is made to fix this problem.

# What are the bugs ?
1. When we name the "output_label" field other than "labels", the webapp displays an error.
2. When a labeled word has some special characters, it breaks the regular expression allowing the plugin to find prelabels
3. If entering a dataset that does not have the right schema for labels data or metadata, the dataset would be erased while it should just be forbidden
4. When selecting words with line breaks in text area, it saves it as `words\n` while is should be escaped

# Where were the bug coming from?
1. The value `labels` is hard coded in the code
2. Labeled words are not escaped when we build the regex allowing the plugin to find the pre-labels
3. The error was not caught the right way
4. We allow to select line breaks or spaces if there are more than one

# How I fixed it?
1. Removed hard coded value with the variable selected by the user for labels column [43a4a23](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/pull/64/commits/43a4a23ec4ff103cbbb944ad353b06c4149dc43a)
2. Escaped every labeled words when building the regex [ed79633](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/pull/64/commits/ed7963391018794aa29ebe6b170a9c3395a103ce)
3. Rewrite the error handler and display an error message if dataset is not empty and does not have the right schema [ac50bc7](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/pull/64/commits/ac50bc7493de76d6a854a9d9867a26483c3daf5c)
4. It is now impossible to select a space or a line break if beginning or finishing with it. The js finds the next word that is not space or breakline for start value

# How to test?
First, install the plugin "ml-assisted-labeling", create a project and upload the following dataset
[testEmptyDataset.csv](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/files/8232797/testEmptyDataset.csv)
- Go to webapp > New visual webapp > Text Labeling
- Create the webapp with any name
- Use the uploaded dataset for `Unlabeled dataset`
- Select column `text`
- Create new datasets for labels and metadata
- Change the default value of `Labels target column name` to `output_labels`
- Check `Activate Prelabeling`
- Choose langage `English`
- Save and launch the backend

**Bug 1**
Try to label any words and save it, there should not be any errors and webapp should work as expected (Previously, as the `Labels target column name ` value is different from default, it would have thrown an error

**Bug 2**
On the second example, select everything around `-->` and `<--`, and save. If there are no errors, it mean that the characters has been excaped successfully

**Bug 3**
Try creating a dummy editable dataset with any data in it and any schema (Should not be empty). Then go to webapp settings and select this dataset as `Labeling metadata dataset`. Save the webapp, you should have an error saying you cannot do that as the dataset is not empty and have a schema. Try to do the same with an empty dataset with ne schema, it should work this time and the dataset should be created

** Bug 4**
Try to select everything that is between `-->` and `<--`. Speces and linebreaks should never been selected and saved as labels
