### PR TITLE
Fix bug in halting values if cardinality < 10

### DIFF
--- a/python-lib/cardinal/criteria.py
+++ b/python-lib/cardinal/criteria.py
@@ -1,10 +1,10 @@
 from itertools import combinations
 
-import dataiku
 import numpy as np
 import logging
 
 try:
+    import dataiku
     lal = dataiku.import_from_plugin('ml-assisted-labeling', 'lal')
 except Exception as e:
     logging.warning("Couldn't import lal from ml-assisted-labeling plugin, will assume it's already in PYTHONPATH")
@@ -75,7 +75,7 @@ def get_halting_values(scores):
     high_indices = np.where(binids >= 10)[0]
     high_index = high_indices[0] if high_indices.size else n - 10
     # Force at least 10 samples to be green
-    high_index = min(n - 10, high_index)
+    high_index = max(min(n - 10, high_index), 0)
 
     # Normalize scores from 0 to 1 for display
     vmin = scores.min()


### PR DESCRIPTION
Fixed the following problem:
```python
n [5]: get_halting_values(np.array([0.9, 0.4, 0.3, 0.5, 0.1]))
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-5-445ffdb6e6bc> in <module>
----> 1 get_halting_values(np.array([0.9, 0.4, 0.3, 0.5, 0.1]))

<ipython-input-4-fec807b0d536> in get_halting_values(scores)
     79 
     80     # Because indices are reverted, we revert the thesholds
---> 81     low_thr = scores[n - high_index - 1]
     82     high_thr = scores[n - low_index - 1]
```

It is now:
```python
In [9]: get_halting_values(np.array([0.9, 0.4, 0.3, 0.5, 0.1]))
Out[9]: (array([0.   , 0.375, 0.15 , 0.2  , 0.8  ]), 0.8, 0.8)
```
Not sure how to add a test for that or if we even want to do it given that the labeling core feature will take over this plugin.