### PR TITLE
ML-Assisted Labeling > Add scroll to category section on non-multilabel labeling types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Version 4.1.0](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/releases/tag/v4.1.1) - Bugfix release - 2023-02
+- 🪲 Fixed bug where category selector was sometimes not scrollable
+
 ## [Version 4.1.0](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/releases/tag/v4.1.0) - New release - 2022-10
 - 🔥 Remove Image classification app
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Version 4.1.0](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/releases/tag/v4.1.1) - Bugfix release - 2023-02
+## [Version 4.1.1](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/releases/tag/v4.1.1) - Bugfix release - 2023-02
 - 🪲 Fixed bug where category selector was sometimes not scrollable
 
 ## [Version 4.1.0](https://github.com/dataiku/dss-plugin-ml-assisted-labeling/releases/tag/v4.1.0) - New release - 2022-10

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "id": "ml-assisted-labeling",
-    "version": "4.1.0",
+    "version": "4.1.1",
     "meta": {
         "label": "ML-assisted Labeling",
         "description": "Label tabular, image, audio and text data efficiently with Active Learning",

--- a/resource/labeling-app/style.css
+++ b/resource/labeling-app/style.css
@@ -245,9 +245,9 @@ canvas {
     margin-right: -5px;
     display: flex;
     flex-direction: column;
-    justify-content: space-around;
     flex-wrap: wrap;
     flex: 1;
+    overflow: scroll;
 }
 
 .category-selector.inactive * {


### PR DESCRIPTION
For image, sound, and tabular data labeling, if you have more categories than what fits on the screen, you cannot scroll. (Note it works for multi-label types.)

[sc-122650]